### PR TITLE
Add support for SignifydNotFound error

### DIFF
--- a/lib/signifyd.rb
+++ b/lib/signifyd.rb
@@ -31,6 +31,7 @@ require 'signifyd/errors/api_connection_error'
 require 'signifyd/errors/authentication_error'
 require 'signifyd/errors/invalid_request_error'
 require 'signifyd/errors/not_implemented_error'
+require 'signifyd/errors/not_found_error'
 
 module Signifyd
   # ssl_bundle_path

--- a/lib/signifyd.rb
+++ b/lib/signifyd.rb
@@ -354,7 +354,7 @@ module Signifyd
   def self.handle_api_error(rcode, rbody)
     error = {}
     case rcode
-    when 400, 404
+    when 400
       error[:message] = "Invalid request"
       error[:param]  = ""
       raise invalid_request_error error, rcode, rbody
@@ -362,6 +362,10 @@ module Signifyd
       error[:message] = "Authentication error"
       error[:param]  = ""
       raise authentication_error error, rcode, rbody
+    when 404
+      error[:message] = "Not found"
+      error[:param]  = ""
+      raise not_found_error error, rcode, rbody
     else
       error[:message] = "API error"
       error[:param]  = ""
@@ -371,6 +375,10 @@ module Signifyd
 
   def self.invalid_request_error(error, rcode, rbody)
     raise InvalidRequestError.new(error[:message], error[:param], rcode, rbody)
+  end
+  
+  def self.not_found_error(error, rcode, rbody)
+    raise NotFoundError.new(error[:message], error[:param], rcode, rbody)
   end
 
   def self.authentication_error(error, rcode, rbody)

--- a/lib/signifyd/errors/not_found_error.rb
+++ b/lib/signifyd/errors/not_found_error.rb
@@ -1,0 +1,4 @@
+module Signifyd
+  class NotFoundError < SignifydError
+  end
+end

--- a/spec/lib/signifyd_base_spec.rb
+++ b/spec/lib/signifyd_base_spec.rb
@@ -380,7 +380,7 @@ describe Signifyd do
           Signifyd.request(:post, '/v2/cases', hash)
         }
 
-        it { lambda { subject }.should raise_error(Signifyd::InvalidRequestError) }
+        it { lambda { subject }.should raise_error(Signifyd::NotFoundError) }
       end
     end
   end
@@ -428,7 +428,7 @@ describe Signifyd do
       Signifyd.api_key = nil
     }
 
-    context 'when 400 or 404' do
+    context 'when 400' do
       subject {
         Signifyd.handle_api_error(400, "{\"error\":true}")
       }
@@ -442,6 +442,14 @@ describe Signifyd do
       }
 
       it { lambda { subject }.should raise_error(Signifyd::AuthenticationError) }
+    end
+
+    context 'when 404' do
+      subject {
+        Signifyd.handle_api_error(404, "{\"error\":true}")
+      }
+
+      it { lambda { subject }.should raise_error(Signifyd::NotFoundError) }
     end
 
     context 'when 500' do


### PR DESCRIPTION
This will allow us to distinguish between a BadRequest and a NotFound errors, when rescuing exceptions within the app. 

Notion ticket:
https://www.notion.so/tophatter/Update-tophatter-signifyd-ruby-library-to-raise-SignifydNotFound-exceptions-upon-404-ca5c16c0859947248e1187dd80e0578e